### PR TITLE
chore: update refs in `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,8 +1,8 @@
 # chore: re-format source-code using `ormolu`
-78ea2f0028970aa6a63ed4c3775a7790a4ec445d
+1d1e60e9d194e988265e509f07351f2f42413617
 
 # chore: run `cabal-fmt`
 3858a93e2de2a9472deda6a9360153383964cfb1
 
 # chore: run `cabal-fmt`
-89a7d616bd1aa4d3ac39250dd875ef98e6f116f9
+1e41c32d4606b939ecac5eef7d77e2971259e6ed


### PR DESCRIPTION
Due to the use of `Rebase and merge` when merging pull-requests on GitHub, refs changed (GitHub actually performs a rebase, even though none is required, hence commit timestamps changing).